### PR TITLE
Enable testimonial widget and assign footer menus in Sydney

### DIFF
--- a/v2/themes/sydney.php
+++ b/v2/themes/sydney.php
@@ -1170,6 +1170,13 @@ function sydney_atss_setup_after_import( $demo_id ) {
 		update_option('sydney_template_builder_data', $template_builder_data);
 	}
 
+	if ( 'main-free' === $demo_id ) {
+		$aafe_modules = get_option( 'athemes-addons-modules' );
+		$aafe_modules = ( is_array( $aafe_modules ) ) ? $aafe_modules : (array) $aafe_modules;
+
+		update_option( 'athemes-addons-modules', array_merge( $aafe_modules, array( 'testimonials' => true ) ) );
+	}
+
 	if ( 'fashion' === $demo_id ) {
 		$merchant_modules = get_option( 'merchant-modules' );
 		$merchant_modules = ( is_array( $merchant_modules ) ) ? $merchant_modules : (array) $merchant_modules;
@@ -1179,7 +1186,7 @@ function sydney_atss_setup_after_import( $demo_id ) {
 		$aafe_modules = get_option( 'athemes-addons-modules' );
 		$aafe_modules = ( is_array( $aafe_modules ) ) ? $aafe_modules : (array) $aafe_modules;
 
-		update_option( 'athemes-addons-modules', array_merge( $aafe_modules, array( 'woo-product-grid' => true ) ) );
+		update_option( 'athemes-addons-modules', array_merge( $aafe_modules, array( 'woo-product-grid' => true, 'testimonials' => true ) ) );
 	}
 
 	if ( 'plumber' === $demo_id ) {

--- a/v2/themes/sydney.php
+++ b/v2/themes/sydney.php
@@ -1175,6 +1175,29 @@ function sydney_atss_setup_after_import( $demo_id ) {
 		$aafe_modules = ( is_array( $aafe_modules ) ) ? $aafe_modules : (array) $aafe_modules;
 
 		update_option( 'athemes-addons-modules', array_merge( $aafe_modules, array( 'testimonials' => true ) ) );
+
+		// Assign footer menus to widgets
+		$footer_menus = array(
+			'Footer 1' => array( 'About' ),
+			'Footer 2' => array( 'Locations' ),
+			'Footer 4' => array( 'Policy' ),
+		);
+
+		foreach ( $footer_menus as $menu_name => $widget_titles ) {
+			$footer_menu = get_term_by( 'name', $menu_name, 'nav_menu' );
+			if ( ! empty( $footer_menu ) ) {
+				$nav_menu_widget = get_option( 'widget_nav_menu' );
+				foreach ( $nav_menu_widget as $key => $widget ) {
+					if ( $key !== '_multiwidget' ) {
+						if ( ! empty( $nav_menu_widget[ $key ]['title'] ) && in_array( $nav_menu_widget[ $key ]['title'], $widget_titles ) ) {
+							$nav_menu_widget[ $key ]['nav_menu'] = $footer_menu->term_id;
+							update_option( 'widget_nav_menu', $nav_menu_widget );
+						}
+					}
+				}
+			}
+		}
+		
 	}
 
 	if ( 'fashion' === $demo_id ) {


### PR DESCRIPTION
Enables the Testimonials widget in the import actions and also assigns the proper footer menus while importing the Agency stater.